### PR TITLE
Make index display average book rating and total review count

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -6,4 +6,8 @@ class Book < ApplicationRecord
 
   has_many :book_authors
   has_many :authors, through: :book_authors
+
+  def average_rating
+    reviews.average(:rating)
+  end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,4 +5,6 @@
   <% book.authors.each do |author| %>
     <%= author.name %>
   <% end %>
+  <p>Average Rating: <%= book.average_rating %></p>
+  <p>Total Reviews: <%= book.reviews.count %></p>
 <% end %>

--- a/spec/features/user_sees_all_books_spec.rb
+++ b/spec/features/user_sees_all_books_spec.rb
@@ -1,15 +1,26 @@
 require 'rails_helper'
 
 describe 'book index' do
-  it 'user sees all books' do
+  before(:each) do
     book_1 = Book.create(title: "Huckleberry Finn", pages: 250, year: 1950)
     author = book_1.authors.create(name: "Mark Twain")
-
+    user = User.create(name: "Joe Shmoe")
+    book_1.reviews.create(title: "Awesome book!", description: "This book is totally awesome", rating: 5, user_id: user.id)
+    book_1.reviews.create(title: "Crappiest book", description: "This book is terrible", rating: 1, user_id: user.id)
+    @books = [book_1]
+  end
+  it 'user sees all books' do
     visit '/books'
 
-    expect(page).to have_content(book_1.title)
-    expect(page).to have_content(book_1.pages)
-    expect(page).to have_content(book_1.year)
-    expect(page).to have_content(author.name)    
+    expect(page).to have_content(@books[0].title)
+    expect(page).to have_content(@books[0].pages)
+    expect(page).to have_content(@books[0].year)
+    expect(page).to have_content(@books[0].authors[0].name)
+  end
+  it 'user sees rating statistics per book' do
+    visit '/books'
+
+    expect(page).to have_content("Average Rating: 3")
+    expect(page).to have_content("Total Reviews: 2")
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -13,4 +13,16 @@ describe Book, type: :model do
     it { should have_many(:book_authors) }
     it { should have_many(:authors).through(:book_authors) }
   end
+
+  describe 'Instance Methods' do
+    it 'can return average rating' do
+      book_1 = Book.create(title: "Huckleberry Finn", pages: 250, year: 1950)
+      author = book_1.authors.create(name: "Mark Twain")
+      user = User.create(name: "Joe Shmoe")
+      book_1.reviews.create(title: "Awesome book!", description: "This book is totally awesome", rating: 5, user_id: user.id)
+      book_1.reviews.create(title: "Crappiest book", description: "This book is terrible", rating: 1, user_id: user.id)
+
+      expect(book_1.average_rating).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
As a Visitor,
When I visit the book index page,
Next to each book title, I see its average book rating
And I also see the total number of reviews for the book.

closes #2 