### PR TITLE
Usershowpagesort#14

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   def show
+    params.permit(:sort_order)
     @user = User.find(params[:id])
+    @reviews = @user.sorted_reviews(params[:sort_order])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,9 @@ class User < ApplicationRecord
     select('users.*, count(reviews) AS review_count')
     .joins(:reviews).group(:id, :user_id).order("review_count DESC").take(3)
   end
+
+  def sorted_reviews(order)
+    order ||= 'desc'
+    reviews.order(created_at: order.to_sym)
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,14 @@
 <div id="user-info">
   <%= @user.name %>
     <div id="reviews-block">
+      <a href="<%= @user.id %>?sort_order=desc">Newest First</a>
+      <a href="<%= @user.id %>?sort_order=asc">Oldest First</a>
       <% @user.reviews.each do |review| %>
-        <%= review.title %>
-        <%= review.description %>
-        <%= review.rating %>
+        <div class="review">
+          <%= review.title %>
+          <%= review.description %>
+          <%= "Rating: #{review.rating}" %>
+        </div>
       <% end %>
     <div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,11 @@
+<div id="user-info">
+  <%= @user.name %>
+    <div id="reviews-block">
+      <% @user.reviews.each do |review| %>
+        <%= review.title %>
+        <%= review.description %>
+        <%= review.rating %>
+      <% end %>
+    <div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show, :new, :create] do
     resources :reviews, only: [:new, :create]
-  end 
+  end
+
+  resources :users, only: [:show]
 
 end

--- a/spec/features/user_sees_user_show_page_spec.rb
+++ b/spec/features/user_sees_user_show_page_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'user show page' do
+  before(:each) do
+    @user = User.create(name: "Joe Shmoe")
+
+    book_1 = Book.create(title: "Huckleberry Finn", pages: 210, year: 1950)
+    author = book_1.authors.create(name: "Mark Twain")
+    book_1.reviews.create(title: "Awesome book!", description: "This book is totally awesome", rating: 5, user: @user)
+
+    book_2 = Book.create(title: "Dune", pages: 900, year: 1950)
+    author = book_2.authors.create(name: "Frank Herbert")
+    book_2.reviews.create(title: "Worst book!", description: "This book is awful", rating: 1, user: @user)
+
+    book_3 = Book.create(title: "Pride and Prejudice", pages: 130, year: 1950)
+    author = book_3.authors.create(name: "Jane Austen")
+    book_3.reviews.create(title: "Pretty Good!", description: "This book is super great!", rating: 4, user: @user)
+
+    @books = [book_1, book_2, book_3]
+  end
+  it 'visitor sees info about user' do
+    visit user_path(@user)
+
+    within '#user-info' do
+      expect(page).to have_content(@user.name)
+      within '#reviews-block' do
+        @user.reviews.each do |review|
+          expect(page).to have_content(review.title)
+          expect(page).to have_content(review.description)
+          expect(page).to have_content(review.rating)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user_sees_user_show_page_spec.rb
+++ b/spec/features/user_sees_user_show_page_spec.rb
@@ -27,9 +27,32 @@ describe 'user show page' do
         @user.reviews.each do |review|
           expect(page).to have_content(review.title)
           expect(page).to have_content(review.description)
-          expect(page).to have_content(review.rating)
+          expect(page).to have_content("Rating: #{review.rating}")
         end
       end
     end
+  end
+  it 'visitor can sort user reviews chronologically ascending' do
+    visit user_path(@user)
+    click_on "Newest First"
+
+    expect(page).to have_current_path(user_path(@user, sort_order: 'desc'))
+    within '#reviews-block' do
+      expect(all('.review')[0]).to have_content("Awesome book!")
+      expect(all('.review')[0]).to have_content("This book is totally awesome")
+      expect(all('.review')[0]).to have_content("Rating: 5")
+      expect(all('.review')[1]).to have_content("Worst book!")
+      expect(all('.review')[1]).to have_content("This book is awful")
+      expect(all('.review')[1]).to have_content("Rating: 1")
+      expect(all('.review')[2]).to have_content("Pretty Good!")
+      expect(all('.review')[2]).to have_content("This book is super great!")
+      expect(all('.review')[2]).to have_content("Rating: 4")
+    end
+  end
+  it 'visitor can sort user reviews chronologically descending' do
+    visit user_path(@user)
+    click_on "Oldest First"
+
+    expect(page).to have_current_path(user_path(@user, sort_order: 'asc'))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,22 @@ describe User, type: :model do
   describe 'Relationship' do
     it { should have_many(:reviews) }
     it { should have_many(:books).through(:reviews)}
+  end
 
+  describe 'Instance Methods' do
+    before(:each) do
+      author = Author.create(name:"823uiahpfd")
+      book = Book.create(title:"191209", authors: [author], pages: 12, year: 1928)
+
+      @user = User.create(name:"oihnoic")
+      @rev_1 = @user.reviews.create(title:"abcd", description:"asdf", book: book, rating: 1)
+      @rev_2 = @user.reviews.create(title:"efgh", description:"qw4", book: book, rating: 2)
+      @rev_3 = @user.reviews.create(title:"ijkl", description:"123wyg456", book: book, rating: 3)
+    end
+    it 'returns reviews in chronological order' do
+      expect(@user.sorted_reviews("asc")[0]).to eq(@rev_1)
+      expect(@user.sorted_reviews("asc")[1]).to eq(@rev_2)
+      expect(@user.sorted_reviews("asc")[2]).to eq(@rev_3)
+    end
   end
 end


### PR DESCRIPTION
Added sort functionality to reviews on user show page. Working and tested.

As a Visitor,
When I click on a user's name for any book review
I am taken to a show page for that user.
I should also see links to sort reviews in the following ways:

sort reviews newest first (descending chronological order)
sort reviews oldest first (ascending chronological order)

closes #14 