### PR TITLE
Create show page for authors that display all books and other unique coauthors

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,0 +1,6 @@
+class AuthorsController < ApplicationController
+
+  def show
+    @author = Author.find(params[:id])
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -28,4 +28,11 @@ class Book < ApplicationRecord
   def average_rating
     reviews.average(:rating)
   end
+
+  def other_authors(author)
+    list = authors.map do |a|
+      a.name if a.name != author.name
+    end
+    list.compact
+  end
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,0 +1,14 @@
+<%= @author.name %>
+<br>
+Books:
+<div id="author-books">
+<% @author.books.each do |book| %><br>
+  Title: <%= book.title %>
+  Number of Pages: <%= book.pages %>
+  Year Published: <%= book.year %>
+  Other Authors:
+  <% book.other_authors(@author).each do |author| %>
+  <%= author %>
+  <% end  %>
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show, :new, :create] do
     resources :reviews, only: [:new, :create]
-  end 
+  end
+
+  resources :authors, only: [:show]
 
 end

--- a/spec/features/user_sees_author_show_page_spec.rb
+++ b/spec/features/user_sees_author_show_page_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe 'author show page' do
+  it 'user sees only one authors info' do
+    author = Author.create(name: "J.K. Rowling")
+    author_2 = Author.create(name: "C.S. Lewis")
+    author_3 = Author.create(name: "HR Shovenstuff")
+
+    book_1 = Book.create(title: "Lion, Witch, and Wardrobe", pages: 800, year: 1925)
+    book_2 = Book.create(title: "Another Book", pages: 300, year: 1960)
+
+    book_1.authors << [author]
+    book_2.authors << [author_2, author_3]
+
+    visit author_path(author)
+
+    expect(page).to have_current_path("/authors/#{author.id}")
+
+    expect(page).to have_content(author.name)
+    expect(page).not_to have_content(author_2.name)
+  end
+  it 'user sees all books written by that one author' do
+    author = Author.create(name: "J.K. Rowling")
+    author_2 = Author.create(name: "C.S. Lewis")
+    author_3 = Author.create(name: "HR Shovenstuff")
+
+    book_1 = Book.create(title: "Lion, Witch, and Wardrobe", pages: 800, year: 1925)
+    book_2 = Book.create(title: "Another Book", pages: 300, year: 1960)
+    book_3 = Book.create(title: "Harry Potter", pages: 125, year: 1970)
+
+    book_1.authors << [author, author_2]
+    book_2.authors << [author_2]
+
+    visit author_path(author_2)
+
+    expect(page).to have_current_path("/authors/#{author_2.id}")
+
+    expect(page).to have_content(author_2.books[0].title)
+    expect(page).to have_content(author_2.books[1].title)
+    expect(page).not_to have_content(book_3.title)
+  end
+  it 'user sees all co-authors for all show author books' do
+    author = Author.create(name: "J.K. Rowling")
+    author_2 = Author.create(name: "C.S. Lewis")
+    author_3 = Author.create(name: "HR Shovenstuff")
+
+    book_1 = Book.create(title: "Lion, Witch, and Wardrobe", pages: 800, year: 1925)
+    book_2 = Book.create(title: "Another Book", pages: 300, year: 1960)
+    book_3 = Book.create(title: "Title", pages: 125, year: 1970)
+
+    book_1.authors << [author, author_2]
+
+    visit author_path(author_2)
+    save_and_open_page
+    expect(page).to have_current_path("/authors/#{author_2.id}")
+
+    within '#author-books' do
+    expect(page).to have_content(book_1.authors[0].name)
+    expect(page).not_to have_content(book_1.authors[1].name)
+  end
+  end
+
+end


### PR DESCRIPTION
As a Visitor,
When I visit an author's show page
I see all book titles by that author
And each book should show its number of pages and any other authors
excluding the author that this show page is about.

closes #11 