### PR TITLE
Add delete functionality to user page for each review and redirects back to user page

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,4 +14,9 @@ class ReviewsController < ApplicationController
     review.user = user
   end
 
+  def destroy
+    Review.find(params[:user_id]).destroy
+    redirect_to(user_path(id: params[:id]))
+  end
+
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,6 +8,9 @@
           <%= review.title %>
           <%= review.description %>
           <%= "Rating: #{review.rating}" %>
+          <div id="delete-<%= review.id %>">
+          <%= link_to "Delete", user_review_path(review), method: :delete, data: {confirm: "Really delete the review?"} %>
+          </div>
         </div>
       <% end %>
     <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     resources :reviews, only: [:new, :create]
   end
 
-  resources :users, only: [:show]
+  resources :users, only: [:show] do
+    resources :reviews, only: [:destroy]
+  end
 
 end

--- a/spec/features/user_deletes_a_review_spec.rb
+++ b/spec/features/user_deletes_a_review_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'user deletes a review' do
+  describe 'they link from the users show page' do
+    it 'displays all users reviews without the deleted review' do
+
+      book_1 = Book.create(title: "Huckleberry Finn", pages: 210, year: 1950)
+      book_2 = Book.create(title: "Dune", pages: 900, year: 1950)
+      user = User.create(name: "Joy Opinions")
+      review_1 = user.reviews.create(title: "Joyful book", description: "This book brought joy to my life", rating: 4, book_id: book_1.id)
+      review_2 = user.reviews.create(title: "No joy", description: "None of the joys were brought by reading this", rating: 2, book_id: book_2.id)
+
+      visit user_path(user)
+      within("#delete-#{review_1.id}") do
+        click_link "Delete"
+      end
+
+      expect(current_path).to eq(user_path(user))
+      expect(page).to have_content(review_2.description)
+      expect(page).not_to have_content(review_1.description)
+    end
+  end
+end


### PR DESCRIPTION
Discussion points - Interestingly, if you pry into the params within the destroy route in the reviews_controller file, it lists the review.id with the key :user_id and the key :id holds the value for the user's id.  Let's look at this together.

As a Visitor,
When I visit a user's show page,
I see a link next to each review to delete the review.
When I delete a review I am returned to the user's show page
Then I should no longer see that review.

closes #15 