### PR TITLE
Add links to user show page via book index page and author show page …

### DIFF
--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -14,7 +14,7 @@ Books:
     <%= book.best_review.title %>
     <%= book.best_review.description %>
     <%= book.best_review.rating %>
-    <%= book.best_review.user.name %>
+    <%= link_to book.best_review.user.name, user_path(book.best_review.user) %>
     <% end  %>
 <% end %>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -30,7 +30,9 @@
 
 <div id="top_reviewers">
   <% @top_3_reviewers.each do |reviewer| %>
-    <div class="reviewer-name"><%= reviewer.name %></div>
+    <div class="reviewer-name">
+      <%= link_to reviewer.name, user_path(reviewer) %>
+    </div>
     Total Reviews: <%= reviewer.review_count  %>
   <% end %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -13,7 +13,9 @@
     <div class="top_review">
       <%= review.title %>
       Rating - <%= review.rating %>
-      <%= review.user.name %>
+      <div id= "top-review-<%= review.id %>">
+        <%=  link_to review.user.name, user_path(review.user) %>
+      </div>
     </div>
   <% end %>
 
@@ -21,7 +23,9 @@
     <div class="bottom_review">
       <%= review.title %>
       Rating - <%= review.rating %>
-      <%= review.user.name %>
+      <div id= "bottom-review-<%= review.id %>">
+        <%= link_to review.user.name, user_path(review.user) %>
+      </div>
     </div>
   <% end %>
 </div>
@@ -30,5 +34,8 @@
   <%= review.title %>
   <%= review.description %>
   <%= review.rating %>
-  <%= review.user.name %>
+  binding.pry
+  <div id="all-reviews-<%= review.id %>">
+    <%= link_to review.user.name, user_path(review.user) %>
+  </div>
 <% end %>

--- a/spec/features/user_sees_all_books_spec.rb
+++ b/spec/features/user_sees_all_books_spec.rb
@@ -129,10 +129,18 @@ describe 'book index' do
     expect(page).to have_current_path(book_path(@books[0]))
 
     visit books_path
-    
+
     within("#bottom_3") do
       click_on @books[0].title
     end
     expect(page).to have_current_path(book_path(@books[0]))
+  end
+  it 'has link to user show page' do
+    visit books_path
+
+    within("#top_reviewers") do
+      click_on @books[0].users[0].name
+    end
+    expect(page).to have_current_path(user_path(@books[0].users[0]))
   end
 end

--- a/spec/features/user_sees_author_show_page_spec.rb
+++ b/spec/features/user_sees_author_show_page_spec.rb
@@ -91,4 +91,17 @@ describe 'author show page' do
   end
     expect(page).to have_current_path(book_path(book))
   end
+  it 'has link to user show page' do
+    author = Author.create(name: "J.K. Rowling")
+    book = author.books.create(title: "Lion, Witch, and Wardrobe", pages: 800, year: 1925)
+    user = User.create(name: "Opinion Ated")
+    book.reviews.create(title: "Worst book!", description: "This book is awful", rating: 1, user_id: user.id)
+    
+    visit author_path(author)
+
+    within("#author-books") do
+      click_on user.name
+    end
+    expect(page).to have_current_path(user_path(user))
+  end
 end

--- a/spec/features/user_sees_book_show_page_spec.rb
+++ b/spec/features/user_sees_book_show_page_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe 'book show page' do
   before (:each) do
-    user = User.create(name: "Joe Shmoe")
+    @user = User.create(name: "Joe Shmoe")
 
     @book = Book.create(title: "Pride and Prejudice", pages: 130, year: 1950)
     @book.authors.create(name: "Jane Austen")
     @book.authors.create(name: "Ghost Writer")
-    @book.reviews.create(title: "Decent", description: "This book is super great!", rating: 3, user_id: user.id)
-    @book.reviews.create(title: "Uh...", description: "I don't get it.", rating: 2, user_id: user.id)
-    @book.reviews.create(title: "Best book evaarrr!", description: "This book is super great!", rating: 5, user_id: user.id)
-    @book.reviews.create(title: "Pretty goood!", description: "This book is super great!", rating: 4, user_id: user.id)
+    @book.reviews.create(title: "Decent", description: "This book is super great!", rating: 3, user_id: @user.id)
+    @book.reviews.create(title: "Uh...", description: "I don't get it.", rating: 2, user_id: @user.id)
+    @book.reviews.create(title: "Best book evaarrr!", description: "This book is super great!", rating: 5, user_id: @user.id)
+    @book.reviews.create(title: "Pretty goood!", description: "This book is super great!", rating: 4, user_id: @user.id)
 
     @other_book = Book.create(title: "Dune", pages: 900, year: 1950)
     author = @other_book.authors.create(name: "Frank Herbert")
@@ -47,6 +47,29 @@ describe 'book show page' do
     click_on "add a new review"
 
     expect(page).to have_current_path(new_book_review_path(book_id: @book.id))
+  end
+
+  it 'has link to user show page' do
+    visit book_path(@book)
+
+    within("#top-review-#{@book.reviews[0].id}") do
+      click_on @user.name
+    end
+    expect(page).to have_current_path(user_path(@user))
+
+    visit book_path(@book)
+
+    within("#bottom-review-#{@book.reviews[0].id}") do
+      click_on @user.name
+    end
+    expect(page).to have_current_path(user_path(@user))
+
+    visit book_path(@book)
+
+    within("#all-reviews-#{@book.reviews[0].id}") do
+      click_on @user.name
+    end
+    expect(page).to have_current_path(user_path(@user))
   end
 
   describe 'statistics' do


### PR DESCRIPTION
…and book show page

As a Visitor,
With the exception of a user's show page,
Anywhere I see a user's name on the site for a book review,
I can click on the name to go to that user's show page.

closes #20 