### PR TITLE
Add author links from book index page and book show page

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -6,7 +6,7 @@
     <%= book.pages %>
     <%= book.year %>
     <% book.authors.each do |author| %>
-      <%= author.name %>
+    <%= link_to author.name, author_path(author) %>
     <% end %>
     <p>Average Rating: <%= book.avg_rating %></p>
     <p>Total Reviews: <%= book.reviews.count %></p>
@@ -21,7 +21,7 @@
     <%= book.pages %>
     <%= book.year %>
     <% book.authors.each do |author| %>
-      <%= author.name %>
+    <%= link_to author.name, author_path(author) %>
     <% end %>
     <p>Average Rating: <%= book.avg_rating %></p>
     <p>Total Reviews: <%= book.reviews.count %></p>
@@ -68,7 +68,7 @@
     <%= book.pages %>
     <%= book.year %>
     <% book.authors.each do |author| %>
-      <%= author.name %>
+      <%= link_to author.name, author_path(author) %>
     <% end %>
     <p>Average Rating: <%= book.avg_rating %></p>
     <p>Total Reviews: <%= book.reviews.count %></p>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,9 +1,11 @@
-<%= @book.title %>
-<%= @book.pages %>
-<%= @book.year %>
-<%  @book.authors.each do |author|%>
-  <%= author.name %>
-<% end %>
+<div id="book-info">
+  <%= @book.title %>
+  <%= @book.pages %>
+  <%= @book.year %>
+  <%  @book.authors.each do |author|%>
+    <%= link_to author.name, author_path(author) %>
+  <% end %>
+</div>
 
 <%= link_to "Delete", book_path(@book), method: :delete, data: {confirm: "Really delete the review?"} %>
 

--- a/spec/features/user_sees_all_books_spec.rb
+++ b/spec/features/user_sees_all_books_spec.rb
@@ -129,10 +129,34 @@ describe 'book index' do
     expect(page).to have_current_path(book_path(@books[0]))
 
     visit books_path
-    
+
     within("#bottom_3") do
       click_on @books[0].title
     end
     expect(page).to have_current_path(book_path(@books[0]))
+  end
+  it 'has links to authors show page' do
+    visit books_path
+
+    within("#top_3") do
+      click_on @books[0].authors[0].name
+    end
+
+    expect(page).to have_current_path(author_path(@books[0].authors[0]))
+
+    visit books_path
+
+    within("#bottom_3") do
+      click_on @books[0].authors[0].name
+    end
+
+    expect(page).to have_current_path(author_path(@books[0].authors[0]))
+
+    visit books_path
+
+    within("#all-books") do
+      click_on @books[0].authors[0].name
+    end
+    expect(page).to have_current_path(author_path(@books[0].authors[0]))
   end
 end

--- a/spec/features/user_sees_book_show_page_spec.rb
+++ b/spec/features/user_sees_book_show_page_spec.rb
@@ -48,6 +48,15 @@ describe 'book show page' do
 
     expect(page).to have_current_path(new_book_review_path(book_id: @book.id))
   end
+  it 'has link to go to author show page' do
+    visit book_path(@book)
+
+    within("#book-info") do
+      click_on @book.authors[0].name
+    end
+
+    expect(page).to have_current_path(author_path(@book.authors[0]))
+  end
 
   describe 'statistics' do
     it 'user sees top 3 reviews' do


### PR DESCRIPTION
As a Visitor,
With the exception of an author's show page,
Anywhere I see an author's name on the site,
I can click on the name to go to that author's show page.

closes #19 