### PR TITLE
Delete author#17

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -7,9 +7,5 @@ class AuthorsController < ApplicationController
   def destroy
     Book.destroy_books_with_single_author(params[:id])
     Author.find(params[:id]).destroy
-    #
-    # where(author_id: author_id).destroy
-    # books_to_delete.destroy
-    # redirect_to(authors_path())
   end
 end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,4 +3,13 @@ class AuthorsController < ApplicationController
   def show
     @author = Author.find(params[:id])
   end
+
+  def destroy
+    Book.destroy_books_with_single_author(params[:id])
+    Author.find(params[:id]).destroy
+    #
+    # where(author_id: author_id).destroy
+    # books_to_delete.destroy
+    # redirect_to(authors_path())
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,6 +1,6 @@
 class Author < ApplicationRecord
   validates_presence_of :name
-  
-  has_many :book_authors
+
+  has_many :book_authors, dependent: :destroy
   has_many :books, through: :book_authors
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,18 +18,14 @@ class Book < ApplicationRecord
   end
 
   def self.destroy_books_with_single_author(author_id)
-    # FIXME: This section updates count when it runs the where, so it
-    # undoes the original filter and keeps only the books with one instance
-    # of the same author. How to fix? Beats me.
     books = select('books.*, count(DISTINCT book_authors) AS auth_count')
     .joins(:book_authors)
     .group(:id, :book_id)
     .having('count(book_authors) = 1')
+    .where("books.id IN (SELECT book_authors.book_id FROM book_authors WHERE author_id = ?)", author_id)
+    .pluck(:id)
 
-    books = books.scoping do
-      where('book_authors.author_id = ?', author_id)
-    end
-    destroy(books_to_delete)
+    destroy(books)
   end
 
   def top_3_reviews

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,7 +4,7 @@ class Book < ApplicationRecord
   has_many :reviews
   has_many :users, through: :reviews
 
-  has_many :book_authors
+  has_many :book_authors, dependent: :nullify
   has_many :authors, through: :book_authors
 
   def self.with_avg_rating(sort_dir, sort_by)
@@ -15,6 +15,21 @@ class Book < ApplicationRecord
       books = books.order("#{sort_by} #{sort_dir}")
     end
     books
+  end
+
+  def self.destroy_books_with_single_author(author_id)
+    # FIXME: This section updates count when it runs the where, so it
+    # undoes the original filter and keeps only the books with one instance
+    # of the same author. How to fix? Beats me.
+    books = select('books.*, count(DISTINCT book_authors) AS auth_count')
+    .joins(:book_authors)
+    .group(:id, :book_id)
+    .having('count(book_authors) = 1')
+
+    books = books.scoping do
+      where('book_authors.author_id = ?', author_id)
+    end
+    destroy(books_to_delete)
   end
 
   def top_3_reviews

--- a/app/models/book_author.rb
+++ b/app/models/book_author.rb
@@ -1,4 +1,14 @@
 class BookAuthor < ApplicationRecord
   belongs_to :book
   belongs_to :author
+
+  def self.book_ids_with_single_author(author_id)
+    # a = select(:book_id)
+    # .where(author_id: author_id)
+    # .group(:id, :book_id)
+    # .having('count(book_id) = 1')
+    # .pluck(:book_id)
+    a = select('book_id, count(authors) AS asdf').where(author_id: author_id).group(:id, :book_id).having('count(author_id) = 1')
+    binding.pry
+  end
 end

--- a/app/models/book_author.rb
+++ b/app/models/book_author.rb
@@ -1,14 +1,4 @@
 class BookAuthor < ApplicationRecord
   belongs_to :book
   belongs_to :author
-
-  def self.book_ids_with_single_author(author_id)
-    # a = select(:book_id)
-    # .where(author_id: author_id)
-    # .group(:id, :book_id)
-    # .having('count(book_id) = 1')
-    # .pluck(:book_id)
-    a = select('book_id, count(authors) AS asdf').where(author_id: author_id).group(:id, :book_id).having('count(author_id) = 1')
-    binding.pry
-  end
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,4 +1,5 @@
 <%= @author.name %>
+<%= link_to "Delete Author", author_path(@author), method: :delete, data: {confirm: "Really delete the author?"} %>
 <br>
 Books:
 <div id="author-books">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
     resources :reviews, only: [:destroy]
   end
 
-  resources :authors, only: [:show]
+  resources :authors, only: [:show, :destroy]
 end

--- a/spec/features/user_deletes_an_author_spec.rb
+++ b/spec/features/user_deletes_an_author_spec.rb
@@ -30,7 +30,5 @@ describe 'user deletes an author' do
 
       expect(Book.exists?(@book_1.id)).to eq(true)
     end
-
-
   end
 end

--- a/spec/features/user_deletes_an_author_spec.rb
+++ b/spec/features/user_deletes_an_author_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'user deletes an author' do
+  describe 'they link from the author show page' do
+    before(:each) do
+      @book_1 = Book.create(title: "Huckleberry Finn", pages: 210, year: 1950)
+      @book_2 = Book.create(title: "Dune", pages: 900, year: 1950)
+
+      @author_1 = @book_1.authors.create(name: "Mark Twain")
+      @author_2 = @book_1.authors.create(name: "Frank Herbert")
+      @author_3 = @book_2.authors.create(name: "Ghost Writer")
+    end
+    it 'removes author entry from database' do
+      visit author_path(@author_3)
+      click_link "Delete Author"
+
+      expect(Author.exists?(@author_3.id)).to eq(false)
+    end
+
+    it 'removes related single author books from database' do
+      visit author_path(@author_3)
+      click_link "Delete Author"
+
+      expect(Book.exists?(@book_2.id)).to eq(false)
+    end
+
+    it 'doesnt remove book if there are multiple authors' do
+      visit author_path(@author_2)
+      click_link "Delete Author"
+
+      expect(Book.exists?(@book_1.id)).to eq(true)
+    end
+
+
+  end
+end


### PR DESCRIPTION
User story implemented and tested:
As a Visitor,
When I visit an author's show page,
I see a link on the page to delete the author.
This link should return me to the book index page where I
no longer see this author listed.
If this author was the only author for any book, that book is also deleted.

closes #17