### PR TITLE
Book dup#42

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -22,7 +22,8 @@ class BooksController < ApplicationController
     params.require(:book).permit(:title, :pages, :year, :authors)
     book_params = process_params(params)
     if book_params == nil
-      redirect_to new_book_path
+      book = Book.find_by(title: params[:book][:title].titleize)
+      redirect_to book_path(book)
     else
       book = Book.create!(book_params)
       redirect_to(book_path(id: book.id)) if book.id

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -21,8 +21,12 @@ class BooksController < ApplicationController
   def create
     params.require(:book).permit(:title, :pages, :year, :authors)
     book_params = process_params(params)
-    book = Book.create!(book_params)
-    redirect_to(book_path(id: book.id)) if book.id
+    if book_params == nil
+      redirect_to new_book_path
+    else
+      book = Book.create!(book_params)
+      redirect_to(book_path(id: book.id)) if book.id
+    end
   end
 
   def process_params(params)

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,4 +1,5 @@
 Add a New Book
+
 <%= form_for @book do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title, placeholder: "Title" %>

--- a/spec/features/user_adds_new_book_spec.rb
+++ b/spec/features/user_adds_new_book_spec.rb
@@ -25,4 +25,18 @@ describe 'new book page' do
 
     expect(page).to have_current_path(book_path(Book.last))
   end
+  it 'cannot be created if the title exists' do
+    book = Book.create(title: 'Farewell To Arms', pages: 650, year: 1934)
+    book.authors.create(name: 'ernest hemmingway')
+
+    visit new_book_path
+
+    fill_in("book[title]", with: "Farewell to Arms")
+    fill_in("book[pages]", with: "650")
+    fill_in("book[authors]", with: "ernest hemmingway, ghost writer")
+    fill_in("book[year]", with: "1934")
+    click_button("Create Book")
+
+    expect(page).to have_current_path(new_book_path)
+  end
 end

--- a/spec/features/user_adds_new_book_spec.rb
+++ b/spec/features/user_adds_new_book_spec.rb
@@ -26,17 +26,17 @@ describe 'new book page' do
     expect(page).to have_current_path(book_path(Book.last))
   end
   it 'cannot be created if the title exists' do
-    book = Book.create(title: 'Farewell To Arms', pages: 650, year: 1934)
-    book.authors.create(name: 'ernest hemmingway')
+    book = Book.create(title: 'Moby Dick', pages: 650, year: 1934)
+    book.authors.create(name: 'Herman Melville')
 
     visit new_book_path
 
-    fill_in("book[title]", with: "Farewell to Arms")
+    fill_in("book[title]", with: "Moby Dick")
     fill_in("book[pages]", with: "650")
     fill_in("book[authors]", with: "ernest hemmingway, ghost writer")
     fill_in("book[year]", with: "1934")
     click_button("Create Book")
 
-    expect(page).to have_current_path(new_book_path)
+    expect(page).to have_current_path(book_path(book))
   end
 end


### PR DESCRIPTION
Make sure books with the same title can't be added twice.  If a user tries to add a book with a non-unique title, they are redirected to the show page for the book that already has that title in the db.

closes #42 